### PR TITLE
Added missing libtool to debian/control BuildDeps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: clutter
 Section: libs
 Priority: optional
 Maintainer: Thomas-Karl Pietrowski <thopiekar@googlemail.com>
-Build-Depends: debhelper, cdbs (>= 0.4), libgles2-dev [armel] | libgles2-sgx-img-dev [armel], libgl-dev [!armel], libgtk2.0-dev, libxcomposite-dev, libxi-dev, libxdamage-dev, opengles-sgx-img-common-dev [armel], docbook-utils, xmlto
+Build-Depends: debhelper, cdbs (>= 0.4), libtool, libgles2-dev [armel] | libgles2-sgx-img-dev [armel], libgl-dev [!armel], libgtk2.0-dev, libxcomposite-dev, libxi-dev, libxdamage-dev, opengles-sgx-img-common-dev [armel], docbook-utils, xmlto
 Standards-Version: 3.7.2
 
 Package: libclutter-0.8-0


### PR DESCRIPTION
See: https://launchpadlibrarian.net/107713161/buildlog_ubuntu-precise-amd64.clutter_0.8.2-0~256~precise1_FAILEDTOBUILD.txt.gz
